### PR TITLE
compile fix and make build easier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/linenoise-ng"]
+	path = external/linenoise-ng
+	url = https://github.com/arangodb/linenoise-ng.git

--- a/db_one_list_subscription/gui_client/meson.build
+++ b/db_one_list_subscription/gui_client/meson.build
@@ -1,21 +1,32 @@
-executable(
-    'fltk_client'
-    , ['FltkClient.cpp', 'GuiClientDataFlow.cpp']
-    , include_directories: inc
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
-
-if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_client'
+        , ['FltkClient.cpp', 'GuiClientDataFlow.cpp']
+        , include_directories: inc
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building fltk_client (FLTK found)')
 else
-    wx = dependency('wxwidgets')
+    message('Skipping fltk_client (FLTK not found)')
 endif
 
-executable(
-    'wx_client'
-    , ['WxClient.cpp', 'GuiClientDataFlow.cpp']
-    , include_directories: inc
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
+if build_machine.system() == 'windows'
+    wx = dependency('wxwidgets-vcpkg', required: false)
+else
+    wx = dependency('wxwidgets', required: false)
+endif
+
+if wx.found()
+    executable(
+        'wx_client'
+        , ['WxClient.cpp', 'GuiClientDataFlow.cpp']
+        , include_directories: inc
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building wx_client (wxWidgets found)')
+else
+    message('Skipping wx_client (wxWidgets not found)')
+endif

--- a/db_one_list_subscription/versionless_gui_client/meson.build
+++ b/db_one_list_subscription/versionless_gui_client/meson.build
@@ -1,21 +1,32 @@
-executable(
-    'fltk_client'
-    , ['FltkClient.cpp', 'GuiClientDataFlow.cpp']
-    , include_directories: inc
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
-
-if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_client'
+        , ['FltkClient.cpp', 'GuiClientDataFlow.cpp']
+        , include_directories: inc
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building versionless fltk_client (FLTK found)')
 else
-    wx = dependency('wxwidgets')
+    message('Skipping versionless fltk_client (FLTK not found)')
 endif
 
-executable(
-    'wx_client'
-    , ['WxClient.cpp', 'GuiClientDataFlow.cpp']
-    , include_directories: inc
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
+if build_machine.system() == 'windows'
+    wx = dependency('wxwidgets-vcpkg', required: false)
+else
+    wx = dependency('wxwidgets', required: false)
+endif
+
+if wx.found()
+    executable(
+        'wx_client'
+        , ['WxClient.cpp', 'GuiClientDataFlow.cpp']
+        , include_directories: inc
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building versionless wx_client (wxWidgets found)')
+else
+    message('Skipping versionless wx_client (wxWidgets not found)')
+endif

--- a/external/meson.build
+++ b/external/meson.build
@@ -1,0 +1,14 @@
+linenoise_inc = include_directories('linenoise-ng/include')
+linenoise_sources = [
+  'linenoise-ng/src/linenoise.cpp',
+  'linenoise-ng/src/ConvertUTF.cpp',
+  'linenoise-ng/src/wcwidth.cpp'
+]
+linenoise_lib = static_library('linenoise-ng', linenoise_sources,
+  include_directories: linenoise_inc,
+  cpp_args: ['-std=c++11']
+)
+linenoise_dep = declare_dependency(
+  link_with: linenoise_lib,
+  include_directories: linenoise_inc
+)

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,8 @@ add_project_arguments(
   language: 'cpp'
 )
 
+subdir('external')
+
 inc = include_directories('.')
 if get_option('buildtype') == 'debug'
   tm_infra_dep = dependency('tm_kit_infra_debug')

--- a/simple_demo/client/data_display/HttpDisplayServer.cpp
+++ b/simple_demo/client/data_display/HttpDisplayServer.cpp
@@ -17,7 +17,11 @@ namespace http = boost::beast::http;
 
 class ConnectionHandler {
 private:
+#if BOOST_VERSION >= 108700
     boost::asio::io_context *svc_;
+#else
+    boost::asio::io_service *svc_;
+#endif
     tcp::acceptor *acceptor_;
     tcp::socket socket_;
     boost::beast::flat_buffer buffer_;
@@ -26,7 +30,11 @@ private:
     std::mutex *valueStorageMutex_;
     std::string path_;
 public:
+#if BOOST_VERSION >= 108700
     ConnectionHandler(boost::asio::io_context *svc, tcp::acceptor *acceptor, double *valueStorage, std::mutex *valueStorageMutex, std::string const &path)
+#else
+    ConnectionHandler(boost::asio::io_service *svc, tcp::acceptor *acceptor, double *valueStorage, std::mutex *valueStorageMutex, std::string const &path)
+#endif
         :
         svc_(svc), acceptor_(acceptor)
         , socket_(*svc), buffer_(), req_()
@@ -95,7 +103,11 @@ int main(int argc, char **argv) {
         return 0;
     }
     int port = (argc>=3)?std::atoi(argv[2]):23456;
+#if BOOST_VERSION >= 108700
     boost::asio::io_context io_service;
+#else
+    boost::asio::io_service io_service;
+#endif
     tcp::acceptor acceptor(io_service, tcp::endpoint(tcp::v4(), port));
     double valueStorage;
     std::mutex valueStorageMutex;

--- a/simple_demo/client/data_display/meson.build
+++ b/simple_demo/client/data_display/meson.build
@@ -28,24 +28,36 @@ executable(
 )
 
 if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+    wx = dependency('wxwidgets-vcpkg', required: false)
 else
-    wx = dependency('wxwidgets')
+    wx = dependency('wxwidgets', required: false)
 endif
 
-executable(
-    'wx_display'
-    , ['WxDisplay.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib]
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
-executable(
-    'fltk_display'
-    , ['FltkDisplay.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib]
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
+if wx.found()
+    executable(
+        'wx_display'
+        , ['WxDisplay.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib]
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building wx_display (wxWidgets found)')
+else
+    message('Skipping wx_display (wxWidgets not found)')
+endif
+
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_display'
+        , ['FltkDisplay.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib]
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building fltk_display (FLTK found)')
+else
+    message('Skipping fltk_display (FLTK not found)')
+endif

--- a/simple_demo/plain_executables/meson.build
+++ b/simple_demo/plain_executables/meson.build
@@ -39,29 +39,40 @@ plain_gui_library = static_library(
     , dependencies: [common_deps]
 )
 
-executable(
-    'fltk_enabler'
-    , ['FltkEnablerGUI.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib, plain_gui_library]
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
-
-if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_enabler'
+        , ['FltkEnablerGUI.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib, plain_gui_library]
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building fltk_enabler (FLTK found)')
 else
-    wx = dependency('wxwidgets')
+    message('Skipping fltk_enabler (FLTK not found)')
 endif
 
-executable(
-    'wx_enabler'
-    , ['WxEnablerGUI.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib, plain_gui_library]
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
+if build_machine.system() == 'windows'
+    wx = dependency('wxwidgets-vcpkg', required: false)
+else
+    wx = dependency('wxwidgets', required: false)
+endif
+
+if wx.found()
+    executable(
+        'wx_enabler'
+        , ['WxEnablerGUI.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib, plain_gui_library]
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building wx_enabler (wxWidgets found)')
+else
+    message('Skipping wx_enabler (wxWidgets not found)')
+endif
 
 #FTXUI library is from https://github.com/ArthurSonzogni/FTXUI
 #it can easily be built with cmake

--- a/simple_demo/secure_executables/meson.build
+++ b/simple_demo/secure_executables/meson.build
@@ -39,29 +39,40 @@ secure_gui_library = static_library(
     , dependencies: [common_deps]
 )
 
-executable(
-    'fltk_enabler'
-    , ['FltkEnablerGUI.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib, tm_simple_demo_security_logic_lib, secure_gui_library]
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
-
-if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_enabler'
+        , ['FltkEnablerGUI.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib, tm_simple_demo_security_logic_lib, secure_gui_library]
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building secure fltk_enabler (FLTK found)')
 else
-    wx = dependency('wxwidgets')
+    message('Skipping secure fltk_enabler (FLTK not found)')
 endif
 
-executable(
-    'wx_enabler'
-    , ['WxEnablerGUI.cpp', test_gen_out]
-    , include_directories: inc
-    , link_with: [tm_simple_demo_proto_lib, tm_simple_demo_security_logic_lib, secure_gui_library]
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
+if build_machine.system() == 'windows'
+    wx = dependency('wxwidgets-vcpkg', required: false)
+else
+    wx = dependency('wxwidgets', required: false)
+endif
+
+if wx.found()
+    executable(
+        'wx_enabler'
+        , ['WxEnablerGUI.cpp', test_gen_out]
+        , include_directories: inc
+        , link_with: [tm_simple_demo_proto_lib, tm_simple_demo_security_logic_lib, secure_gui_library]
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building secure wx_enabler (wxWidgets found)')
+else
+    message('Skipping secure wx_enabler (wxWidgets not found)')
+endif
 
 #FTXUI library is from https://github.com/ArthurSonzogni/FTXUI
 #it can easily be built with cmake

--- a/simple_demo_chain_version/executables/enable_client/meson.build
+++ b/simple_demo_chain_version/executables/enable_client/meson.build
@@ -16,33 +16,55 @@ executable(
     , ['LineNoiseMain.cpp']
     , include_directories: [inc]
     , link_with: [enable_client_gui_library]
-    , dependencies: [common_deps, dependency('linenoise-ng')]
+    , dependencies: [common_deps, linenoise_dep]
 )
-executable(
-    'ftxui_enable_client'
-    , ['FTXUIMain.cpp', prebuild_ftxui_info_header]
-    , include_directories: [inc]
-    , link_with: [enable_client_gui_library]
-    , dependencies: [common_deps, dependency('ftxui')]
-)
-executable(
-    'fltk_enable_client'
-    , ['FltkMain.cpp']
-    , include_directories: [inc]
-    , link_with: [enable_client_gui_library]
-    , dependencies: [common_deps, dependency('fltk')]
-    , gui_app: true
-)
-if build_machine.system() == 'windows'
-    wx = dependency('wxwidgets-vcpkg')
+
+# GUI libraries are optional dependencies
+ftxui_dep = dependency('ftxui', required: false)
+if ftxui_dep.found()
+    executable(
+        'ftxui_enable_client'
+        , ['FTXUIMain.cpp', prebuild_ftxui_info_header]
+        , include_directories: [inc]
+        , link_with: [enable_client_gui_library]
+        , dependencies: [common_deps, ftxui_dep]
+    )
+    message('Building ftxui_enable_client (FTXUI found)')
 else
-    wx = dependency('wxwidgets')
+    message('Skipping ftxui_enable_client (FTXUI not found)')
 endif
-executable(
-    'wx_enable_client'
-    , ['WxMain.cpp']
-    , include_directories: [inc]
-    , link_with: [enable_client_gui_library]
-    , dependencies: [common_deps, wx]
-    , gui_app: true
-)
+
+fltk_dep = dependency('fltk', required: false)
+if fltk_dep.found()
+    executable(
+        'fltk_enable_client'
+        , ['FltkMain.cpp']
+        , include_directories: [inc]
+        , link_with: [enable_client_gui_library]
+        , dependencies: [common_deps, fltk_dep]
+        , gui_app: true
+    )
+    message('Building fltk_enable_client (FLTK found)')
+else
+    message('Skipping fltk_enable_client (FLTK not found)')
+endif
+
+if build_machine.system() == 'windows'
+    wx = dependency('wxwidgets-vcpkg', required: false)
+else
+    wx = dependency('wxwidgets', required: false)
+endif
+
+if wx.found()
+    executable(
+        'wx_enable_client'
+        , ['WxMain.cpp']
+        , include_directories: [inc]
+        , link_with: [enable_client_gui_library]
+        , dependencies: [common_deps, wx]
+        , gui_app: true
+    )
+    message('Building wx_enable_client (wxWidgets found)')
+else
+    message('Skipping wx_enable_client (wxWidgets not found)')
+endif

--- a/transaction_redundancy_test/meson.build
+++ b/transaction_redundancy_test/meson.build
@@ -1,5 +1,5 @@
 transaction_redundancy_test_dep = [
-    dependency('linenoise-ng')
+    linenoise_dep
     , dependency('libetcdcpp')
     , dependency('boost', modules: ['program_options'])
 #    , dependency('google_cloud_cpp_common')
@@ -14,7 +14,7 @@ executable(
     , dependencies: [common_deps, transaction_redundancy_test_dep]
 )
 # to make it easier to go between Linux and Windows
-# , as of now, this example uses pre-generated protobuf 
+# , as of now, this example uses pre-generated protobuf
 # headers and sources
 executable(
     'transaction_server'


### PR DESCRIPTION
1. fix a boost::asci compile error
2. add linenoise-ng as submodule and make some gui libraries optional to make it easier to build